### PR TITLE
Adding cl for when we need to compile defun* macro

### DIFF
--- a/foreman.el
+++ b/foreman.el
@@ -30,6 +30,8 @@
 
 ;;; Code:
 
+(eval-when-compile (require 'cl))
+
 (defun foreman-shell-readonly-scroll-and-truncate ()
   (make-local-variable 'comint-scroll-show-maximum-output)
   (make-local-variable 'comint-buffer-maximum-size)


### PR DESCRIPTION
I had trouble using the library due to not have the cl library loaded.  I believe its only needed for compiling that defun\* macro following this Emacs Wiki entry:

http://www.emacswiki.org/emacs/CommonLispForEmacs

I added the this line to load it for compiling only:

```
(eval-when-compile (require 'cl))
```
